### PR TITLE
Fix httputils wrapped target path

### DIFF
--- a/src/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Security/Http/HttpUtils.php
+++ b/src/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Security/Http/HttpUtils.php
@@ -77,7 +77,14 @@ class HttpUtils
      */
     public function createWrappedTargetPath(Request $request, $otp)
     {
-        return sprintf('%s&%s=%s', $request->get($this->targetPathParameter), $this->otpParameter, rawurlencode($otp));
+        $targetPath = $request->get($this->targetPathParameter);
+
+        return sprintf(
+            (false === strpos($targetPath, '?')) ? '%s?%s=%s' : '%s&%s=%s',
+            $targetPath,
+            $this->otpParameter,
+            rawurlencode($otp)
+        );
     }
 
     /**

--- a/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/Application/autoload.php
+++ b/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/Application/autoload.php
@@ -10,4 +10,8 @@ $loader = require __DIR__.'/../../../../../../vendor/autoload.php';
 
 AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
 
+if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase')) {
+    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
+}
+
 return $loader;

--- a/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/DependencyInjection/Compiler/ServiceProvidersPassTest.php
+++ b/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/DependencyInjection/Compiler/ServiceProvidersPassTest.php
@@ -35,7 +35,7 @@ class ServiceProvidersPassTest extends \PHPUnit_Framework_TestCase
         $this->container->expects($this->any())
             ->method('findTaggedServiceIds')
             ->willReturnMap(array(
-                array('sso.service_provider', array(
+                array('sso.service_provider', false, array(
                     'acme_bundle.sso.consumer1' => array(
                         array(
                             'service' => 'consumer1'

--- a/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/DependencyInjection/KrtvSingleSignOnIdentityProviderExtensionTest.php
+++ b/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/DependencyInjection/KrtvSingleSignOnIdentityProviderExtensionTest.php
@@ -3,7 +3,6 @@
 namespace Krtv\Bundle\SingleSignOnIdentityProviderBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 /**
  * Class KrtvSingleSignOnIdentityProviderExtensionTest
@@ -17,6 +16,14 @@ class KrtvSingleSignOnIdentityProviderExtensionTest extends \PHPUnit_Framework_T
     public function testLoad()
     {
         $container = new ContainerBuilder();
+        // remove default aliases of 'service_container' : Psr\Container\ContainerInterface  & Symfony\Component\DependencyInjection\ContainerInterface
+        foreach ($container->getAliases() as $id => $alias) {
+            $container->removeAlias($id);
+        }
+        // default definition like of 'service_container'
+        foreach ($container->getDefinitions() as $id => $definition) {
+            $container->removeDefinition($id);
+        }
 
         $configs = array(
             array(

--- a/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/EventListener/TargetPathSubscriberTest.php
+++ b/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/EventListener/TargetPathSubscriberTest.php
@@ -79,9 +79,6 @@ class TargetPathSubscriberTest extends \PHPUnit_Framework_TestCase
             ->method('getSessionService')
             ->willReturn(null);
         $serviceManagerMock->expects($this->never())
-            ->method('setRequestService')
-            ->willReturn(null);
-        $serviceManagerMock->expects($this->never())
             ->method('setSessionService')
             ->willReturn(null);
 

--- a/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/KrtvSingleSignOnIdentityProviderBundleTest.php
+++ b/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/KrtvSingleSignOnIdentityProviderBundleTest.php
@@ -14,7 +14,7 @@ class KrtvSingleSignOnIdentityProviderBundleTest extends \PHPUnit_Framework_Test
      */
     public function testCompilerPassesAreRegistered()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
 
         $container->expects($this->exactly(3))
             ->method('addCompilerPass')

--- a/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/Manager/ServiceManagerTest.php
+++ b/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/Manager/ServiceManagerTest.php
@@ -32,8 +32,8 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidInvocation()
     {
-        $this->setExpectedException('RuntimeException', 'No ServiceProvider managers found. Make sure that you have at least one ServiceProvider manager tagged with "sso.service_provider"');
-
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('No ServiceProvider managers found. Make sure that you have at least one ServiceProvider manager tagged with "sso.service_provider"');
         new ServiceManager(new RequestStack(), $this->getSessionMock(), 'main', array(), array(
             'service_parameter' => 'service',
             'service_extra_parameter' => 'service_extra',
@@ -84,7 +84,8 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionWhenGetServiceManager()
     {
-        $this->setExpectedException('InvalidArgumentException', 'Unknown service consumer2');
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Unknown service consumer2');
 
         $serviceManager = new ServiceManager(new RequestStack(), $this->getSessionMock(), 'main', array(
             'consumer1' => $consumer1 = $this->getConsumerMock('consumer1')

--- a/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/Security/Http/HttpUtilsTest.php
+++ b/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/Security/Http/HttpUtilsTest.php
@@ -43,14 +43,27 @@ class HttpUtilsTest extends \PHPUnit_Framework_TestCase
     /**
      *
      */
-    public function testCreateWrappedTargetPath()
+    public function testCreateWrappedTargetPathWithoutQuestionMark()
     {
         $request = new Request(array('_target_path' => '/foo'));
         $httpUtils = $this->getHttpUtils();
 
         $wrappedTargetPath = $httpUtils->createWrappedTargetPath($request, 'xyz');
 
-        $this->assertEquals('/foo&_otp=xyz', $wrappedTargetPath);
+        $this->assertEquals('/foo?_otp=xyz', $wrappedTargetPath);
+    }
+
+    /**
+     *
+     */
+    public function testCreateWrappedTargetPathWithQuestionMark()
+    {
+        $request = new Request(array('_target_path' => '/foo?bar=foobar'));
+        $httpUtils = $this->getHttpUtils();
+
+        $wrappedTargetPath = $httpUtils->createWrappedTargetPath($request, 'xyz');
+
+        $this->assertEquals('/foo?bar=foobar&_otp=xyz', $wrappedTargetPath);
     }
 
     /**


### PR DESCRIPTION
Into createWrappedTargetPath() method, when targetPath does not contain the question mark "?",  we have to add it for buildind the query string