### PR TITLE
Fix security logout absolute url

### DIFF
--- a/src/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Manager/LogoutManager.php
+++ b/src/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Manager/LogoutManager.php
@@ -71,7 +71,7 @@ class LogoutManager
             return $serviceManager->getServiceLogoutUrl();
         }
 
-        return $this->router->generate('_security_logout');
+        return $this->router->generate('_security_logout', array(), RouterInterface::ABSOLUTE_URL);
     }
 
     /**

--- a/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/Manager/LogoutManagerTest.php
+++ b/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/Manager/LogoutManagerTest.php
@@ -125,7 +125,7 @@ class LogoutManagerTest extends \PHPUnit_Framework_TestCase
         $routerMock->expects($this->once())
             ->method('generate')
             ->willReturnMap(array(
-                array('_security_logout', array(), UrlGeneratorInterface::ABSOLUTE_PATH, 'http://idp.example.com/logout')
+                array('_security_logout', array(), UrlGeneratorInterface::ABSOLUTE_URL, 'http://idp.example.com/logout')
             ));
 
         $logoutManager = new LogoutManager($serviceManagerMock, $this->getSessionMock(), $routerMock);

--- a/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/Manager/ServiceManagerTest.php
+++ b/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/Manager/ServiceManagerTest.php
@@ -28,12 +28,11 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
     private $consumers = array();
 
     /**
-     *
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage No ServiceProvider managers found. Make sure that you have at least one ServiceProvider manager tagged with "sso.service_provider"
      */
     public function testInvalidInvocation()
     {
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('No ServiceProvider managers found. Make sure that you have at least one ServiceProvider manager tagged with "sso.service_provider"');
         new ServiceManager(new RequestStack(), $this->getSessionMock(), 'main', array(), array(
             'service_parameter' => 'service',
             'service_extra_parameter' => 'service_extra',
@@ -80,13 +79,11 @@ class ServiceManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Unknown service consumer2
      */
     public function testExceptionWhenGetServiceManager()
     {
-        $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('Unknown service consumer2');
-
         $serviceManager = new ServiceManager(new RequestStack(), $this->getSessionMock(), 'main', array(
             'consumer1' => $consumer1 = $this->getConsumerMock('consumer1')
         ), array(


### PR DESCRIPTION
The issue is concerning DEV environnement only.
The router::generate() method already add /app_dev.php before path.
The httpUtils::createRedirectResponse() method add the /app_dev.php too.
The final result of SingleSignOnController::ssoLogoutAction() is : /app_dev.php/app_dev.php/logout
Generate route with absolute_url fixes this issue on DEV environnement.