### PR TITLE
use absolute url for security logout

### DIFF
--- a/src/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Manager/LogoutManager.php
+++ b/src/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Manager/LogoutManager.php
@@ -71,7 +71,7 @@ class LogoutManager
             return $serviceManager->getServiceLogoutUrl();
         }
 
-        return $this->router->generate('_security_logout');
+        return $this->router->generate('_security_logout', array(), true);
     }
 
     /**


### PR DESCRIPTION
Already fixed in version 0.3.x, but that version is only available for symfony 2.8 and up. For lower versions this fix is important as well.