### PR TITLE
Wrong redirect response, when redirect uri host is not the same as server host

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
 

--- a/src/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Security/Http/HttpUtils.php
+++ b/src/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Security/Http/HttpUtils.php
@@ -52,22 +52,28 @@ class HttpUtils
      * @param Request $request
      * @param string  $path
      * @param int     $status
+     *
      * @return RedirectResponse
+     * @throws \LogicException
+     * @throws \InvalidArgumentException
      */
     public function createRedirectResponse(Request $request, $path, $status = 302)
     {
-        return $this->httpUtils->createRedirectResponse($request, $path, $status);
+        return new RedirectResponse($this->httpUtils->generateUri($request, $path), $status);
     }
 
     /**
      * @param Request $request
      * @param string  $path
      * @param int     $status
+     *
      * @return RedirectResponse
+     * @throws \LogicException
+     * @throws \InvalidArgumentException
      */
     public function createSignedRedirectResponse(Request $request, $path, $status = 302)
     {
-        return $this->httpUtils->createRedirectResponse($request, $this->uriSigner->sign($path), $status);
+        return new RedirectResponse($this->httpUtils->generateUri($request, $this->uriSigner->sign($path)), $status);
     }
 
     /**

--- a/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/Routing/SsoRoutesLoaderTest.php
+++ b/tests/Krtv/Bundle/SingleSignOnIdentityProviderBundle/Tests/Routing/SsoRoutesLoaderTest.php
@@ -38,7 +38,7 @@ class KrtvSingleSignOnIdentityProviderBundleTest extends \PHPUnit_Framework_Test
             ->getMock();
 
         $this->getSsoRoutesLoader()->setResolver($resolverMock);
-        $this->getSsoRoutesLoader()->getResolver();
+        $this->assertNull($this->getSsoRoutesLoader()->getResolver());
     }
 
     /**


### PR DESCRIPTION
Since symfony 3.3.13(https://github.com/symfony/security-http/commit/f3545ba1637095fb8dbce2fb7cf8cb5735c126a1) it's impossible to use `\Symfony\Component\Security\Http\HttpUtils::createRedirectResponse` method to create redirect response for the url which has different host comparing to the server host. To fix this issue redirect response should be created manually.   